### PR TITLE
Feature: Add a setting for the type of ajax response

### DIFF
--- a/forms_builder/forms/views.py
+++ b/forms_builder/forms/views.py
@@ -63,7 +63,7 @@ class FormDetail(TemplateView):
         return self.render_to_response(context)
 
     def render_to_response(self, context, **kwargs):
-        if self.request.is_ajax():
+        if self.request.is_ajax() and getattr(settings, 'FORM_BUILDER_AJAX_RESPONSE_TYPE', 'json') == 'json':
             json_context = json.dumps({
                 "errors": context["form_for_form"].errors,
                 "form": context["form_for_form"].as_p(),


### PR DESCRIPTION
I'm currently using the form builder to create forms which are used in a DjangoCMS plugin. Each form is submitted using an ajax call but I'm using a modified template. I don't want to have too much logic in the front-end so I just want to display the form like it would render without an ajax call. By simply adding a setting we are able to 'turn off' the default JSON response and simply use the template.

In the template it is still possible to make changes using `{% if request.is_ajax %}...ajax template logic{%endif %}`.

Of course this isn't the only solution but settings which allow you to change the output are always a good thing.